### PR TITLE
Rename logger and make debug logging optional

### DIFF
--- a/copylot/__init__.py
+++ b/copylot/__init__.py
@@ -5,13 +5,23 @@ except ImportError:
 
 import logging
 
-def enable_debug_logging(log_filepath = 'copylot_debug_log.txt'):
+
+def enable_debug_logging(log_filepath: str = 'copylot_debug_log.txt'):
+    """
+    Enable debug logging to a text file
+
+    Parameters
+    ----------
+    log_filepath : str
+        Path to log file, by default 'copylot_debug_log.txt'
+    """
     # create file handler which logs debug messages
     fh = logging.FileHandler(log_filepath)
     fh.setLevel(logging.DEBUG)
     fh.setFormatter(formatter)
 
     logger.addHandler(fh)
+
 
 logger = logging.getLogger('copylot')
 logger.setLevel(logging.DEBUG)

--- a/copylot/__init__.py
+++ b/copylot/__init__.py
@@ -6,7 +6,10 @@ except ImportError:
 import logging
 
 
-def enable_debug_logging(log_filepath: str = 'copylot_debug_log.txt'):
+def enable_logging(
+    log_filepath: str = 'copylot_debug_log.txt',
+    level = logging.DEBUG,
+):
     """
     Enable debug logging to a text file
 
@@ -17,7 +20,7 @@ def enable_debug_logging(log_filepath: str = 'copylot_debug_log.txt'):
     """
     # create file handler which logs debug messages
     fh = logging.FileHandler(log_filepath)
-    fh.setLevel(logging.DEBUG)
+    fh.setLevel(level)
     fh.setFormatter(formatter)
 
     logger.addHandler(fh)

--- a/copylot/__init__.py
+++ b/copylot/__init__.py
@@ -17,6 +17,8 @@ def enable_logging(
     ----------
     log_filepath : str
         Path to log file, by default 'copylot_debug_log.txt'
+    level : int
+        Logging level, by default logging.DEBUG
     """
     # create file handler which logs debug messages
     fh = logging.FileHandler(log_filepath)

--- a/copylot/__init__.py
+++ b/copylot/__init__.py
@@ -5,12 +5,16 @@ except ImportError:
 
 import logging
 
-logger = logging.getLogger('application')
-logger.setLevel(logging.DEBUG)
+def enable_debug_logging(log_filepath = 'copylot_debug_log.txt'):
+    # create file handler which logs debug messages
+    fh = logging.FileHandler(log_filepath)
+    fh.setLevel(logging.DEBUG)
+    fh.setFormatter(formatter)
 
-# create file handler which logs even debug messages
-fh = logging.FileHandler('log.txt')
-fh.setLevel(logging.DEBUG)
+    logger.addHandler(fh)
+
+logger = logging.getLogger('copylot')
+logger.setLevel(logging.DEBUG)
 
 # create console handler with a higher log level
 ch = logging.StreamHandler()
@@ -20,9 +24,7 @@ ch.setLevel(logging.INFO)
 formatter = logging.Formatter(
     '%(asctime)s - %(levelname)s - %(module)s.%(funcName)s - %(message)s'
 )
-fh.setFormatter(formatter)
 ch.setFormatter(formatter)
 
 # add the handlers to the logger
-logger.addHandler(fh)
 logger.addHandler(ch)


### PR DESCRIPTION
This PR changed the name of the copylot logger from `application` to `copylot` and makes debug logging to a text file optional. Debug logging can be enabled with:

```python
import copylot

copylot.enable_logging()
```